### PR TITLE
fix: removed empty methods as test case for build errors

### DIFF
--- a/auth-service/src/test/java/com/gold/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/gold/AuthServiceApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class AuthServiceApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }

--- a/resource-service/src/test/java/com/gold/ResourceServiceApplicationTests.java
+++ b/resource-service/src/test/java/com/gold/ResourceServiceApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ResourceServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
 }


### PR DESCRIPTION
비어있는 테스트케이스 때문인지 각 프로젝트별 루트 경로에서 `./gradlew build` 실행 시 아래와 같은 에러가 발생합니다.

<img width="1032" alt="Screenshot 2024-10-07 at 1 16 38 AM" src="https://github.com/user-attachments/assets/48bc2555-ab66-422a-a0b5-c597f99b8128">

테스트 클래스 내 불필요한 빈 메서드를 제거하여 빌드가 정상동작 하도록 수정하였습니다.
